### PR TITLE
feat: add custom provider support with auto model discovery

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parchi-extension",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Warm-paper browser automation extension with configurable LLM providers",
   "private": true,
   "type": "module",

--- a/packages/extension/ai/providers/instance-migrate.ts
+++ b/packages/extension/ai/providers/instance-migrate.ts
@@ -29,6 +29,7 @@ export const materializeProfileWithProvider = (
     customEndpoint: asString(provider.customEndpoint),
     extraHeaders: asRecord(provider.extraHeaders),
     model: modelId || asString(profile.model),
+    sdkType: provider.sdkType || undefined,
   };
 };
 

--- a/packages/extension/ai/providers/model-listing.ts
+++ b/packages/extension/ai/providers/model-listing.ts
@@ -39,6 +39,7 @@ export function extractModelEntries(payload: unknown): ModelEntry[] {
         display_name?: unknown;
         context_length?: unknown;
         contextWindow?: unknown;
+        owned_by?: unknown;
       };
       const id = typeof e.id === 'string' ? e.id.trim() : typeof e.slug === 'string' ? e.slug.trim() : '';
       if (!id) continue;
@@ -51,6 +52,7 @@ export function extractModelEntries(payload: unknown): ModelEntry[] {
             : typeof e.contextWindow === 'number'
               ? e.contextWindow
               : undefined,
+        owned_by: typeof e.owned_by === 'string' ? e.owned_by : undefined,
       });
     }
   }

--- a/packages/extension/ai/providers/types.ts
+++ b/packages/extension/ai/providers/types.ts
@@ -33,4 +33,5 @@ export interface ModelEntry {
   label?: string;
   contextWindow?: number;
   supportsVision?: boolean;
+  owned_by?: string;
 }

--- a/packages/extension/ai/sdk/provider-standard.ts
+++ b/packages/extension/ai/sdk/provider-standard.ts
@@ -58,6 +58,15 @@ export function resolveCustomProvider(
     throw new Error('Custom provider requires a customEndpoint to be configured');
   }
 
+  // Use Anthropic SDK for anthropic-compatible custom providers
+  if (settings.sdkType === 'anthropic') {
+    return createAnthropic({
+      apiKey,
+      baseURL: toAnthropicBaseUrl(rawBase),
+      headers: buildAnthropicCompatibleHeaders('custom', apiKey, extraHeaders),
+    })(modelId);
+  }
+
   return createOpenAICompatible({
     name: 'custom',
     apiKey,

--- a/packages/extension/ai/sdk/provider-types.ts
+++ b/packages/extension/ai/sdk/provider-types.ts
@@ -12,4 +12,6 @@ export type SDKModelSettings = {
   oauthAccessToken?: string;
   oauthApiBaseUrl?: string;
   oauthApiHeaders?: Record<string, string>;
+  /** SDK type for custom providers */
+  sdkType?: 'anthropic' | 'openai' | 'openai-compatible';
 };

--- a/packages/extension/manifest.firefox.json
+++ b/packages/extension/manifest.firefox.json
@@ -12,7 +12,7 @@
       }
     }
   },
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Warm-paper browser automation assistant with configurable LLM/vision profiles and enterprise-ready controls",
   "permissions": [
     "activeTab",

--- a/packages/extension/manifest.json
+++ b/packages/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Parchi",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Warm-paper browser automation assistant with configurable LLM/vision profiles and enterprise-ready controls",
   "permissions": [
     "sidePanel",

--- a/packages/extension/sidepanel/ui/core/panel-ui.ts
+++ b/packages/extension/sidepanel/ui/core/panel-ui.ts
@@ -81,7 +81,7 @@ export class SidePanelUI {
   };
   auxAgentProfiles: string[];
   currentView: 'chat' | 'history';
-  currentSettingsTab: 'providers' | 'model' | 'generation' | 'advanced';
+  currentSettingsTab: 'providers' | 'model' | 'generation' | 'display' | 'advanced';
   profileEditorTarget: string;
   subagents: Map<string, SubagentEntry>;
   activeAgent: string;

--- a/packages/extension/sidepanel/ui/settings/panel-provider-cards.ts
+++ b/packages/extension/sidepanel/ui/settings/panel-provider-cards.ts
@@ -1,5 +1,6 @@
 import type { ProviderInstance } from '@parchi/shared';
 import { PROVIDER_REGISTRY, fetchModelsForProvider, getApiKeyProviders } from '../../../ai/providers/registry.js';
+import type { ProviderDefinition } from '../../../ai/providers/types.js';
 import { mergeProviderModels } from '../../../state/provider-models.js';
 import {
   buildProviderInstanceId,
@@ -162,6 +163,7 @@ sidePanelProto.saveProviderEditorConfig = function saveProviderEditorConfig() {
       createdAt: Number(existing?.createdAt || Date.now()),
       updatedAt: Date.now(),
       source: existing?.source || 'manual',
+      sdkType: existing?.sdkType,
     },
     def.models?.[0]?.id || '',
   );
@@ -256,4 +258,141 @@ sidePanelProto.populateProviderDropdown = function populateProviderDropdown() {
 sidePanelProto.initProviderCardListeners = function initProviderCardListeners() {
   this.elements.providerEditorSaveBtn?.addEventListener('click', () => this.saveProviderEditorConfig());
   this.elements.providerEditorCancelBtn?.addEventListener('click', () => this.closeProviderEditor());
+
+  // Custom provider form listeners
+  this.elements.addCustomProviderBtn?.addEventListener('click', () => this.openCustomProviderForm());
+  this.elements.customProviderFormCloseBtn?.addEventListener('click', () => this.closeCustomProviderForm());
+  this.elements.customProviderSaveBtn?.addEventListener('click', () => this.saveCustomProvider());
+  this.elements.customProviderCancelBtn?.addEventListener('click', () => this.closeCustomProviderForm());
+};
+
+sidePanelProto.openCustomProviderForm = function openCustomProviderForm() {
+  const form = this.elements.customProviderForm as HTMLElement | null;
+  if (!form) return;
+  form.classList.remove('hidden');
+  // Clear form fields
+  if (this.elements.customProviderName) this.elements.customProviderName.value = '';
+  if (this.elements.customProviderSdkType) this.elements.customProviderSdkType.value = 'openai-compatible';
+  if (this.elements.customProviderEndpoint) this.elements.customProviderEndpoint.value = '';
+  if (this.elements.customProviderApiKey) this.elements.customProviderApiKey.value = '';
+  if (this.elements.customProviderModels) this.elements.customProviderModels.value = '';
+  this.elements.customProviderName?.focus();
+};
+
+sidePanelProto.closeCustomProviderForm = function closeCustomProviderForm() {
+  this.elements.customProviderForm?.classList.add('hidden');
+};
+
+sidePanelProto.saveCustomProvider = async function saveCustomProvider() {
+  const name = this.elements.customProviderName?.value?.trim();
+  const sdkType = this.elements.customProviderSdkType?.value || 'openai-compatible';
+  const endpoint = this.elements.customProviderEndpoint?.value?.trim();
+  const apiKey = this.elements.customProviderApiKey?.value?.trim();
+  const modelsRaw = this.elements.customProviderModels?.value?.trim() || '';
+
+  if (!name) {
+    this.updateStatus('Provider name is required', 'warning');
+    return;
+  }
+  if (!endpoint) {
+    this.updateStatus('Base URL is required', 'warning');
+    return;
+  }
+  if (!apiKey) {
+    this.updateStatus('API key is required', 'warning');
+    return;
+  }
+
+  // Parse manually entered models
+  const manualModelIds = modelsRaw
+    .split(',')
+    .map((m: string) => m.trim())
+    .filter(Boolean);
+  let models = manualModelIds.map((id: string) => ({ id, label: id }));
+
+  // Try to fetch models from the endpoint
+  const isAnthropic = sdkType === 'anthropic';
+  const tempDef: ProviderDefinition = {
+    key: 'custom',
+    name,
+    type: 'api-key',
+    sdkType: isAnthropic ? 'anthropic' : 'openai-compatible',
+    defaultBaseUrl: endpoint,
+    authHeaderStyle: isAnthropic ? 'x-api-key' : 'bearer',
+    supportsModelListing: true,
+    modelsEndpoint: isAnthropic ? '/v1/models' : '/models',
+  };
+
+  this.updateStatus(`Fetching models from ${endpoint}...`, 'active');
+
+  try {
+    let fetched = await fetchModelsForProvider(tempDef, { type: 'api-key', apiKey, customEndpoint: endpoint });
+
+    // Filter models based on SDK type if endpoint returns mixed providers
+    if (fetched.length > 0 && isAnthropic) {
+      // Check if owned_by field is present in responses
+      const hasOwnedBy = fetched.some((m: any) => typeof m.owned_by === 'string');
+      if (hasOwnedBy) {
+        // Use owned_by field for accurate filtering
+        const anthropicModels = fetched.filter((m: any) => m.owned_by === 'anthropic');
+        if (anthropicModels.length > 0) {
+          fetched = anthropicModels;
+        }
+      }
+      // If no owned_by field, keep all models - user selected Anthropic SDK intentionally
+    }
+
+    if (fetched.length > 0) {
+      // Merge fetched models with any manually entered ones
+      const fetchedIds = new Set(fetched.map((m) => m.id));
+      const manualOnly = models.filter((m) => !fetchedIds.has(m.id));
+      models = [...fetched, ...manualOnly];
+    }
+  } catch (err) {
+    console.warn('[custom-provider] Failed to fetch models:', err);
+  }
+
+  if (models.length === 0) {
+    this.updateStatus('No models found. Enter at least one model ID manually.', 'warning');
+    return;
+  }
+
+  const providerId = buildProviderInstanceId({
+    provider: 'custom',
+    authType: 'api-key',
+    customEndpoint: endpoint,
+    apiKey,
+    name,
+  });
+
+  const provider: ProviderInstance = ensureProviderModel(
+    {
+      id: providerId,
+      name,
+      provider: 'custom',
+      authType: 'api-key',
+      apiKey,
+      customEndpoint: endpoint,
+      extraHeaders: {},
+      isConnected: true,
+      models,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      source: 'manual',
+      sdkType,
+    },
+    models[0]?.id || '',
+  );
+
+  this.providers = {
+    ...(this.providers || {}),
+    [provider.id]: provider,
+  };
+
+  this.closeCustomProviderForm();
+  this.populateProviderDropdown?.();
+  this.renderApiProviderGrid();
+  this.renderModelSelectorGrid?.();
+  void this.persistAllSettings();
+  this.updateStatus(`${name} added with ${models.length} model${models.length === 1 ? '' : 's'}`, 'success');
 };

--- a/packages/shared/src/provider-instance.ts
+++ b/packages/shared/src/provider-instance.ts
@@ -64,6 +64,8 @@ export interface ProviderInstance extends Omit<Partial<ProviderInstanceBase>, 'p
   updatedAt: number;
   /** Source of this provider instance */
   source?: 'migration' | 'manual' | 'oauth-sync' | 'factory';
+  /** SDK type for custom providers (openai-compatible, anthropic, etc.) */
+  sdkType?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes the non-functional **Add Provider** button and wires up the full custom provider flow.

## Changes

### Bug fix
- **Add Provider button was a no-op** — event listeners for the custom provider form were never bound (`initProviderCardListeners` only covered the existing API key editor)

### Custom provider form
- Open/close/clear form on button click
- Validate name, base URL, and API key before saving
- **Block save if zero models** — keeps form open with a warning instead of saving an unusable provider

### Auto model discovery
- Fetches model list from the endpoint on save (`/v1/models` for Anthropic-compatible, `/models` for OpenAI-compatible)
- Filters fetched models by `owned_by` field when present (handles mixed-provider proxies like local LLM routers)
- Falls back to keeping all models if `owned_by` is absent (endpoint schema not guaranteed)
- Merges fetched models with any manually entered IDs

### Anthropic-compatible SDK routing
- Added `sdkType` field to `ProviderInstance` and `SDKModelSettings`
- `resolveCustomProvider()` now routes through `createAnthropic` when `sdkType === 'anthropic'`
- `materializeProfileWithProvider()` propagates `sdkType` from provider instance into the runtime profile
- `saveProviderEditorConfig()` preserves `sdkType` on edit (previously lost on any key/endpoint update)

### Minor fixes
- Added `display` to `currentSettingsTab` type union (pre-existing TS error)
- `owned_by` field added to `ModelEntry` type and extracted in `extractModelEntries`